### PR TITLE
Fix example deps

### DIFF
--- a/examples/listAndDetailFirebase3/package.json
+++ b/examples/listAndDetailFirebase3/package.json
@@ -7,11 +7,11 @@
     "babel-polyfill": "^6.7.4",
     "babel-runtime": "^6.6.1",
     "firebase": "^3.0.3",
-    "firebase-nest": "^0.0.35",
+    "firebase-nest": "0.0.38",
     "mobx": "^2.2.1",
     "mobx-firebase-store": "^0.1.16",
     "mobx-react": "^3.3.0",
-    "react": "^0.14.8",
+    "react": "^15.1.0",
     "react-dom": "^15.0.2"
   },
   "devDependencies": {
@@ -23,7 +23,8 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
-    "babel-register": "^6.8.0"
+    "babel-register": "^6.8.0",
+    "webpack": "^1.13.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Thanks for the library! Here are just some small fixes to the firebase 3 example to allow `npm i` to work properly
- adds `webpack`, without which we cannot run a server
- `react` and `firebase-nest` were failing peer dep requirements
